### PR TITLE
move browsers with less than 5% market share to separate file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -73,10 +73,10 @@ Additionally, each mixin uses the correct vendor prefixes as indicated by [CSS3P
 
 There are five different editions:
 
-* `prefixer.less` contains prefixes for popular browsers.
-* `prefixer-all.less` contains prefixes for all browsers.
-* `prefixer-nofilter.less` contains prefixes for popular browsers, with filters for IE ommitted.
-* `prefixer-nofilter-all.less` contains prefixes for all browsers, with filters for IE ommitted.
+* `prefixer.less` contains prefixes for all browsers.
+* `prefixer-nofilter.less` contains prefixes for all browsers, with filters for IE ommitted.
+* `prefixer-core.less` contains prefixes for only major rendering engines.
+* `prefixer-nofilter-core.less` contains prefixes for only major rendering engines, with filters for IE ommitted.
 * `prefixer-webkit.less` contains only prefixes for webkit browsers.
 
 ## Credits

--- a/prefixer-core.less
+++ b/prefixer-core.less
@@ -1,5 +1,5 @@
 /*---------------------------------------------------
-    LESS Prefixer for all browsers
+    LESS Prefixer for major browsers
   ---------------------------------------------------
     
     All of the CSS3 fun, none of the prefixes!
@@ -71,49 +71,41 @@
     -webkit-animation: @args;
     -moz-animation: @args;
     -ms-animation: @args;
-    -o-animation: @args;
 }
 .animation-delay(@delay) {
     -webkit-animation-delay: @delay;
     -moz-animation-delay: @delay;
     -ms-animation-delay: @delay;
-    -o-animation-delay: @delay;
 }
 .animation-direction(@direction) {
     -webkit-animation-direction: @direction;
     -moz-animation-direction: @direction;
     -ms-animation-direction: @direction;
-    -o-animation-direction: @direction;
 }
 .animation-duration(@duration) {
     -webkit-animation-duration: @duration;
     -moz-animation-duration: @duration;
     -ms-animation-duration: @duration;
-    -o-animation-duration: @duration;
 }
 .animation-iteration-count(@count) {
     -webkit-animation-iteration-count: @count;
     -moz-animation-iteration-count: @count;
     -ms-animation-iteration-count: @count;
-    -o-animation-iteration-count: @count;
 }
 .animation-name(@name) {
     -webkit-animation-name: @name;
     -moz-animation-name: @name;
     -ms-animation-name: @name;
-    -o-animation-name: @name;
 }
 .animation-play-state(@state) {
     -webkit-animation-play-state: @state;
     -moz-animation-play-state: @state;
     -ms-animation-play-state: @state;
-    -o-animation-play-state: @state;
 }
 .animation-timing-function(@function) {
     -webkit-animation-timing-function: @function;
     -moz-animation-timing-function: @function;
     -ms-animation-timing-function: @function;
-    -o-animation-timing-function: @function;
 }
 
 
@@ -203,7 +195,6 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2);
-    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2);
 }
 .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3) {
@@ -212,7 +203,6 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
-    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
 }
 .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3,@color4,@stop4) {
@@ -221,7 +211,6 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
-    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2) {
@@ -230,7 +219,6 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2);
-    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3) {
@@ -239,7 +227,6 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
-    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3,@color4,@stop4) {
@@ -248,7 +235,6 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
-    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
 }
 
@@ -272,7 +258,6 @@
     -webkit-transform: @args; 
     -moz-transform: @args; 
     -ms-transform: @args; 
-    -o-transform: @args; 
     transform: @args;
 }
 .rotate(@deg:45deg){
@@ -299,30 +284,25 @@
 .transition(@args:200ms) {
     -webkit-transition: @args;
     -moz-transition: @args;
-    -o-transition: @args;
     transition: @args;
 }
 .transition-delay(@delay:0) {
     -webkit-transition-delay: @delay;
     -moz-transition-delay: @delay;
-    -o-transition-delay: @delay;
     transition-delay: @delay;
 }
 .transition-duration(@duration:200ms) {
     -webkit-transition-duration: @duration;
     -moz-transition-duration: @duration;
-    -o-transition-duration: @duration;
     transition-duration: @duration;
 }
 .transition-property(@property:all) {
     -webkit-transition-property: @property;
     -moz-transition-property: @property;
-    -o-transition-property: @property;
     transition-property: @property;
 }
 .transition-timing-function(@function:ease) {
     -webkit-transition-timing-function: @function;
     -moz-transition-timing-function: @function;
-    -o-transition-timing-function: @function;
     transition-timing-function: @function;
 }

--- a/prefixer-nofilter-core.less
+++ b/prefixer-nofilter-core.less
@@ -1,5 +1,5 @@
 /*---------------------------------------------------
-    LESS Prefixer with No Filters
+    LESS Prefixer for major browsers with No Filters
   ---------------------------------------------------
     
     All of the CSS3 fun, none of the prefixes!
@@ -71,49 +71,41 @@
     -webkit-animation: @args;
     -moz-animation: @args;
     -ms-animation: @args;
-    -o-animation: @args;
 }
 .animation-delay(@delay) {
     -webkit-animation-delay: @delay;
     -moz-animation-delay: @delay;
     -ms-animation-delay: @delay;
-    -o-animation-delay: @delay;
 }
 .animation-direction(@direction) {
     -webkit-animation-direction: @direction;
     -moz-animation-direction: @direction;
     -ms-animation-direction: @direction;
-    -o-animation-direction: @direction;
 }
 .animation-duration(@duration) {
     -webkit-animation-duration: @duration;
     -moz-animation-duration: @duration;
     -ms-animation-duration: @duration;
-    -o-animation-duration: @duration;
 }
 .animation-iteration-count(@count) {
     -webkit-animation-iteration-count: @count;
     -moz-animation-iteration-count: @count;
     -ms-animation-iteration-count: @count;
-    -o-animation-iteration-count: @count;
 }
 .animation-name(@name) {
     -webkit-animation-name: @name;
     -moz-animation-name: @name;
     -ms-animation-name: @name;
-    -o-animation-name: @name;
 }
 .animation-play-state(@state) {
     -webkit-animation-play-state: @state;
     -moz-animation-play-state: @state;
     -ms-animation-play-state: @state;
-    -o-animation-play-state: @state;
 }
 .animation-timing-function(@function) {
     -webkit-animation-timing-function: @function;
     -moz-animation-timing-function: @function;
     -ms-animation-timing-function: @function;
-    -o-animation-timing-function: @function;
 }
 
 
@@ -203,7 +195,6 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2);
-    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2);
 }
 .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3) {
@@ -212,7 +203,6 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
-    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
 }
 .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3,@color4,@stop4) {
@@ -221,7 +211,6 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
-    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2) {
@@ -230,7 +219,6 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2);
-    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3) {
@@ -239,7 +227,6 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
-    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3,@color4,@stop4) {
@@ -248,7 +235,6 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
-    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
 }
 
@@ -270,7 +256,6 @@
     -webkit-transform: @args; 
     -moz-transform: @args; 
     -ms-transform: @args; 
-    -o-transform: @args; 
     transform: @args;
 }
 .rotate(@deg:45deg){
@@ -297,30 +282,25 @@
 .transition(@args:200ms) {
     -webkit-transition: @args;
     -moz-transition: @args;
-    -o-transition: @args;
     transition: @args;
 }
 .transition-delay(@delay:0) {
     -webkit-transition-delay: @delay;
     -moz-transition-delay: @delay;
-    -o-transition-delay: @delay;
     transition-delay: @delay;
 }
 .transition-duration(@duration:200ms) {
     -webkit-transition-duration: @duration;
     -moz-transition-duration: @duration;
-    -o-transition-duration: @duration;
     transition-duration: @duration;
 }
 .transition-property(@property:all) {
     -webkit-transition-property: @property;
     -moz-transition-property: @property;
-    -o-transition-property: @property;
     transition-property: @property;
 }
 .transition-timing-function(@function:ease) {
     -webkit-transition-timing-function: @function;
     -moz-transition-timing-function: @function;
-    -o-transition-timing-function: @function;
     transition-timing-function: @function;
 }

--- a/prefixer-nofilter.less
+++ b/prefixer-nofilter.less
@@ -1,5 +1,5 @@
 /*---------------------------------------------------
-    LESS Prefixer for all browsers with No Filters
+    LESS Prefixer with No Filters
   ---------------------------------------------------
     
     All of the CSS3 fun, none of the prefixes!
@@ -71,41 +71,49 @@
     -webkit-animation: @args;
     -moz-animation: @args;
     -ms-animation: @args;
+    -o-animation: @args;
 }
 .animation-delay(@delay) {
     -webkit-animation-delay: @delay;
     -moz-animation-delay: @delay;
     -ms-animation-delay: @delay;
+    -o-animation-delay: @delay;
 }
 .animation-direction(@direction) {
     -webkit-animation-direction: @direction;
     -moz-animation-direction: @direction;
     -ms-animation-direction: @direction;
+    -o-animation-direction: @direction;
 }
 .animation-duration(@duration) {
     -webkit-animation-duration: @duration;
     -moz-animation-duration: @duration;
     -ms-animation-duration: @duration;
+    -o-animation-duration: @duration;
 }
 .animation-iteration-count(@count) {
     -webkit-animation-iteration-count: @count;
     -moz-animation-iteration-count: @count;
     -ms-animation-iteration-count: @count;
+    -o-animation-iteration-count: @count;
 }
 .animation-name(@name) {
     -webkit-animation-name: @name;
     -moz-animation-name: @name;
     -ms-animation-name: @name;
+    -o-animation-name: @name;
 }
 .animation-play-state(@state) {
     -webkit-animation-play-state: @state;
     -moz-animation-play-state: @state;
     -ms-animation-play-state: @state;
+    -o-animation-play-state: @state;
 }
 .animation-timing-function(@function) {
     -webkit-animation-timing-function: @function;
     -moz-animation-timing-function: @function;
     -ms-animation-timing-function: @function;
+    -o-animation-timing-function: @function;
 }
 
 
@@ -195,6 +203,7 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2);
+    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2);
 }
 .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3) {
@@ -203,6 +212,7 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
+    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
 }
 .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3,@color4,@stop4) {
@@ -211,6 +221,7 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
+    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2) {
@@ -219,6 +230,7 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2);
+    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3) {
@@ -227,6 +239,7 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
+    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3,@color4,@stop4) {
@@ -235,6 +248,7 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
+    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
 }
 
@@ -256,6 +270,7 @@
     -webkit-transform: @args; 
     -moz-transform: @args; 
     -ms-transform: @args; 
+    -o-transform: @args; 
     transform: @args;
 }
 .rotate(@deg:45deg){
@@ -282,25 +297,30 @@
 .transition(@args:200ms) {
     -webkit-transition: @args;
     -moz-transition: @args;
+    -o-transition: @args;
     transition: @args;
 }
 .transition-delay(@delay:0) {
     -webkit-transition-delay: @delay;
     -moz-transition-delay: @delay;
+    -o-transition-delay: @delay;
     transition-delay: @delay;
 }
 .transition-duration(@duration:200ms) {
     -webkit-transition-duration: @duration;
     -moz-transition-duration: @duration;
+    -o-transition-duration: @duration;
     transition-duration: @duration;
 }
 .transition-property(@property:all) {
     -webkit-transition-property: @property;
     -moz-transition-property: @property;
+    -o-transition-property: @property;
     transition-property: @property;
 }
 .transition-timing-function(@function:ease) {
     -webkit-transition-timing-function: @function;
     -moz-transition-timing-function: @function;
+    -o-transition-timing-function: @function;
     transition-timing-function: @function;
 }

--- a/prefixer.less
+++ b/prefixer.less
@@ -71,41 +71,49 @@
     -webkit-animation: @args;
     -moz-animation: @args;
     -ms-animation: @args;
+    -o-animation: @args;
 }
 .animation-delay(@delay) {
     -webkit-animation-delay: @delay;
     -moz-animation-delay: @delay;
     -ms-animation-delay: @delay;
+    -o-animation-delay: @delay;
 }
 .animation-direction(@direction) {
     -webkit-animation-direction: @direction;
     -moz-animation-direction: @direction;
     -ms-animation-direction: @direction;
+    -o-animation-direction: @direction;
 }
 .animation-duration(@duration) {
     -webkit-animation-duration: @duration;
     -moz-animation-duration: @duration;
     -ms-animation-duration: @duration;
+    -o-animation-duration: @duration;
 }
 .animation-iteration-count(@count) {
     -webkit-animation-iteration-count: @count;
     -moz-animation-iteration-count: @count;
     -ms-animation-iteration-count: @count;
+    -o-animation-iteration-count: @count;
 }
 .animation-name(@name) {
     -webkit-animation-name: @name;
     -moz-animation-name: @name;
     -ms-animation-name: @name;
+    -o-animation-name: @name;
 }
 .animation-play-state(@state) {
     -webkit-animation-play-state: @state;
     -moz-animation-play-state: @state;
     -ms-animation-play-state: @state;
+    -o-animation-play-state: @state;
 }
 .animation-timing-function(@function) {
     -webkit-animation-timing-function: @function;
     -moz-animation-timing-function: @function;
     -ms-animation-timing-function: @function;
+    -o-animation-timing-function: @function;
 }
 
 
@@ -195,6 +203,7 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2);
+    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2);
 }
 .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3) {
@@ -203,6 +212,7 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
+    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3);
 }
 .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3,@color4,@stop4) {
@@ -211,6 +221,7 @@
     background-image: -webkit-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -moz-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -ms-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
+    background-image: -o-linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: linear-gradient(top, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2) {
@@ -219,6 +230,7 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2);
+    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3) {
@@ -227,6 +239,7 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
+    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3);
 }
 .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,@color3,@stop3,@color4,@stop4) {
@@ -235,6 +248,7 @@
     background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -moz-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: -ms-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
+    background-image: -o-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
     background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
 }
 
@@ -258,6 +272,7 @@
     -webkit-transform: @args; 
     -moz-transform: @args; 
     -ms-transform: @args; 
+    -o-transform: @args; 
     transform: @args;
 }
 .rotate(@deg:45deg){
@@ -284,25 +299,30 @@
 .transition(@args:200ms) {
     -webkit-transition: @args;
     -moz-transition: @args;
+    -o-transition: @args;
     transition: @args;
 }
 .transition-delay(@delay:0) {
     -webkit-transition-delay: @delay;
     -moz-transition-delay: @delay;
+    -o-transition-delay: @delay;
     transition-delay: @delay;
 }
 .transition-duration(@duration:200ms) {
     -webkit-transition-duration: @duration;
     -moz-transition-duration: @duration;
+    -o-transition-duration: @duration;
     transition-duration: @duration;
 }
 .transition-property(@property:all) {
     -webkit-transition-property: @property;
     -moz-transition-property: @property;
+    -o-transition-property: @property;
     transition-property: @property;
 }
 .transition-timing-function(@function:ease) {
     -webkit-transition-timing-function: @function;
     -moz-transition-timing-function: @function;
+    -o-transition-timing-function: @function;
     transition-timing-function: @function;
 }


### PR DESCRIPTION
When I see hand-crafted CSS it's rare that I see the Opera vendor prefix included. Since many CSS writers are trying to conserve bandwidth, I think it's worth moving the Opera rules to a separate file that contains an exhaustive list of vendor prefixes.
