### PR TITLE
Change CSS comments to LESS comments

### DIFF
--- a/prefixer-nofilter.less
+++ b/prefixer-nofilter.less
@@ -1,72 +1,73 @@
-/*---------------------------------------------------
-    LESS Prefixer with No Filters
-  ---------------------------------------------------
-    
-    All of the CSS3 fun, none of the prefixes!
+//---------------------------------------------------
+//  LESS Prefixer with No Filters
+//---------------------------------------------------
+//
+//  All of the CSS3 fun, none of the prefixes!
+//
+//  As a rule, you can use the CSS properties you
+//  would expect just by adding a '.':
+//
+//  box-shadow => .box-shadow(@args)
+//
+//  Also, when shorthand is available, arguments are
+//  not parameterized. Learn CSS, not LESS Prefixer.
+//
+//  -------------------------------------------------
+//  TABLE OF CONTENTS
+//  (*) denotes a syntax-sugar helper
+//  -------------------------------------------------
+//
+//      .animation(@args)
+//          .animation-delay(@delay)
+//          .animation-direction(@direction)
+//          .animation-duration(@duration)
+//          .animation-iteration-count(@count)
+//          .animation-name(@name)
+//          .animation-play-state(@state)
+//          .animation-timing-function(@function)
+//      .background-size(@args)
+//      .border-radius(@args)
+//      .box-shadow(@args)
+//          .inner-shadow(@args) *
+//      .box-sizing(@args)
+//          .border-box() *
+//          .content-box() *
+//      .columns(@args)
+//          .column-count(@count)
+//          .column-gap(@gap)
+//          .column-rule(@args)
+//          .column-width(@width)
+//      .gradient(@default,@start,@stop) *
+//          .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
+//          .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
+//      .opacity(@factor)
+//      .transform(@args)
+//          .rotate(@deg)
+//          .scale(@factor)
+//          .translate(@x,@y)
+//          .translate3d(@x,@y,@z)
+//          .translateHardware(@x,@y) *
+//      .text-shadow(@args)
+//      .transition(@args)
+//          .transition-delay(@delay)
+//          .transition-duration(@duration)
+//          .transition-property(@property)
+//          .transition-timing-function(@function)
+//
+//
+//
+//  Credit to LESS Elements for the motivation and
+//  to CSS3Please.com for implementation.
+//
+//  Copyright (c) 2012 Joel Sutherland
+//  MIT Licensed:
+//  http://www.opensource.org/licenses/mit-license.php
+//
+//---------------------------------------------------
 
-    As a rule, you can use the CSS properties you
-    would expect just by adding a '.':
 
-    box-shadow => .box-shadow(@args)
+// Animation
 
-    Also, when shorthand is available, arguments are
-    not parameterized. Learn CSS, not LESS Prefixer.
-
-    -------------------------------------------------
-    TABLE OF CONTENTS
-    (*) denotes a syntax-sugar helper
-    -------------------------------------------------
-
-        .animation(@args)
-            .animation-delay(@delay)
-            .animation-direction(@direction)
-            .animation-duration(@duration)
-            .animation-iteration-count(@count)
-            .animation-name(@name)
-            .animation-play-state(@state)
-            .animation-timing-function(@function)
-        .background-size(@args)
-        .border-radius(@args)
-        .box-shadow(@args)
-            .inner-shadow(@args) *
-        .box-sizing(@args)
-            .border-box() *
-            .content-box() *
-        .columns(@args)
-            .column-count(@count)
-            .column-gap(@gap)
-            .column-rule(@args)
-            .column-width(@width)
-        .gradient(@default,@start,@stop) *
-            .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
-            .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
-        .opacity(@factor)
-        .transform(@args)
-            .rotate(@deg)
-            .scale(@factor)
-            .translate(@x,@y)
-            .translate3d(@x,@y,@z)
-            .translateHardware(@x,@y) *
-        .text-shadow(@args)
-        .transition(@args)
-            .transition-delay(@delay)
-            .transition-duration(@duration)
-            .transition-property(@property)
-            .transition-timing-function(@function)
-
-
-
-    Credit to LESS Elements for the motivation and
-    to CSS3Please.com for implementation.
-
-    Copyright (c) 2012 Joel Sutherland
-    MIT Licensed:
-    http://www.opensource.org/licenses/mit-license.php
-
------------------------------------------------------*/
-
-
-/* Animation */
 .animation(@args) {
     -webkit-animation: @args;
     -moz-animation: @args;
@@ -117,7 +118,7 @@
 }
 
 
-/* Background Size */
+// Background Size
 
 .background-size(@args) {
     -webkit-background-size: @args;
@@ -126,7 +127,7 @@
 }
 
 
-/* Border Radius */
+// Border Radius
 
 .border-radius(@args) {
     -webkit-border-radius: @args;
@@ -139,7 +140,8 @@
 }
 
 
-/* Box Shadows */
+// Box Shadows
+
 .box-shadow(@args) {
     -webkit-box-shadow: @args;
     -moz-box-shadow: @args;
@@ -150,7 +152,8 @@
 }
 
 
-/* Box Sizing */
+// Box Sizing
+
 .box-sizing(@args){
     -webkit-box-sizing: @args;
     -moz-box-sizing: @args;
@@ -164,8 +167,8 @@
 }
 
 
+// Columns
 
-/* Columns */
 .columns(@args){
     -webkit-columns: @args;
     -moz-columns: @args;
@@ -193,7 +196,8 @@
 }
 
 
-/* Gradients */
+// Gradients
+
 .gradient(@default: #F5F5F5, @start: #EEE, @stop: #FFF) {
     .linear-gradient-top(@default,@start,0%,@stop,100%);
 }
@@ -253,18 +257,21 @@
 }
 
 
-/* Opacity */
+// Opacity
+
 .opacity(@factor){
     opacity: @factor;
 }
 
 
-/* Text Shadow */
+// Text Shadow
+
 .text-shadow(@args){
     text-shadow: @args;
 }
 
-/* Transforms */
+
+// Transforms
 
 .transform(@args) {
     -webkit-transform: @args; 
@@ -292,7 +299,7 @@
 }
 
 
-/* Transitions */
+// Transitions
 
 .transition(@args:200ms) {
     -webkit-transition: @args;
@@ -324,3 +331,4 @@
     -o-transition-timing-function: @function;
     transition-timing-function: @function;
 }
+

--- a/prefixer-webkit.less
+++ b/prefixer-webkit.less
@@ -1,72 +1,73 @@
-/*---------------------------------------------------
-    LESS Prefixer for Webkit Only
-  ---------------------------------------------------
-    
-    All of the CSS3 fun, none of the prefixes!
+//---------------------------------------------------
+//  LESS Prefixer for Webkit Only
+//---------------------------------------------------
+//
+//  All of the CSS3 fun, none of the prefixes!
+//
+//  As a rule, you can use the CSS properties you
+//  would expect just by adding a '.':
+//
+//  box-shadow => .box-shadow(@args)
+//
+//  Also, when shorthand is available, arguments are
+//  not parameterized. Learn CSS, not LESS Prefixer.
+//
+//  -------------------------------------------------
+//  TABLE OF CONTENTS
+//  (*) denotes a syntax-sugar helper
+//  -------------------------------------------------
+//
+//      .animation(@args)
+//          .animation-delay(@delay)
+//          .animation-direction(@direction)
+//          .animation-duration(@duration)
+//          .animation-iteration-count(@count)
+//          .animation-name(@name)
+//          .animation-play-state(@state)
+//          .animation-timing-function(@function)
+//      .background-size(@args)
+//      .border-radius(@args)
+//      .box-shadow(@args)
+//          .inner-shadow(@args) *
+//      .box-sizing(@args)
+//          .border-box() *
+//          .content-box() *
+//      .columns(@args)
+//          .column-count(@count)
+//          .column-gap(@gap)
+//          .column-rule(@args)
+//          .column-width(@width)
+//      .gradient(@default,@start,@stop) *
+//          .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
+//          .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
+//      .opacity(@factor)
+//      .transform(@args)
+//          .rotate(@deg)
+//          .scale(@factor)
+//          .translate(@x,@y)
+//          .translate3d(@x,@y,@z)
+//          .translateHardware(@x,@y) *
+//      .text-shadow(@args)
+//      .transition(@args)
+//          .transition-delay(@delay)
+//          .transition-duration(@duration)
+//          .transition-property(@property)
+//          .transition-timing-function(@function)
+//
+//
+//
+//  Credit to LESS Elements for the motivation and
+//  to CSS3Please.com for implementation.
+//
+//  Copyright (c) 2012 Joel Sutherland
+//  MIT Licensed:
+//  http://www.opensource.org/licenses/mit-license.php
+//
+//---------------------------------------------------
 
-    As a rule, you can use the CSS properties you
-    would expect just by adding a '.':
 
-    box-shadow => .box-shadow(@args)
+// Animation
 
-    Also, when shorthand is available, arguments are
-    not parameterized. Learn CSS, not LESS Prefixer.
-
-    -------------------------------------------------
-    TABLE OF CONTENTS
-    (*) denotes a syntax-sugar helper
-    -------------------------------------------------
-
-        .animation(@args)
-            .animation-delay(@delay)
-            .animation-direction(@direction)
-            .animation-duration(@duration)
-            .animation-iteration-count(@count)
-            .animation-name(@name)
-            .animation-play-state(@state)
-            .animation-timing-function(@function)
-        .background-size(@args)
-        .border-radius(@args)
-        .box-shadow(@args)
-            .inner-shadow(@args) *
-        .box-sizing(@args)
-            .border-box() *
-            .content-box() *
-        .columns(@args)
-            .column-count(@count)
-            .column-gap(@gap)
-            .column-rule(@args)
-            .column-width(@width)
-        .gradient(@default,@start,@stop) *
-            .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
-            .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
-        .opacity(@factor)
-        .transform(@args)
-            .rotate(@deg)
-            .scale(@factor)
-            .translate(@x,@y)
-            .translate3d(@x,@y,@z)
-            .translateHardware(@x,@y) *
-        .text-shadow(@args)
-        .transition(@args)
-            .transition-delay(@delay)
-            .transition-duration(@duration)
-            .transition-property(@property)
-            .transition-timing-function(@function)
-
-
-
-    Credit to LESS Elements for the motivation and
-    to CSS3Please.com for implementation.
-
-    Copyright (c) 2012 Joel Sutherland
-    MIT Licensed:
-    http://www.opensource.org/licenses/mit-license.php
-
------------------------------------------------------*/
-
-
-/* Animation */
 .animation(@args) {
     -webkit-animation: @args;
 }
@@ -93,7 +94,7 @@
 }
 
 
-/* Background Size */
+// Background Size
 
 .background-size(@args) {
     -webkit-background-size: @args;
@@ -101,7 +102,7 @@
 }
 
 
-/* Border Radius */
+// Border Radius
 
 .border-radius(@args) {
     -webkit-border-radius: @args;
@@ -112,7 +113,8 @@
 }
 
 
-/* Box Shadows */
+// Box Shadows
+
 .box-shadow(@args) {
     -webkit-box-shadow: @args;
     box-shadow: @args;
@@ -122,7 +124,8 @@
 }
 
 
-/* Box Sizing */
+// Box Sizing
+
 .box-sizing(@args){
     -webkit-box-sizing: @args;
     box-sizing: @args;
@@ -135,8 +138,8 @@
 }
 
 
+// Columns
 
-/* Columns */
 .columns(@args){
     -webkit-columns: @args;
     columns: @args;
@@ -159,7 +162,8 @@
 }
 
 
-/* Gradients */
+// Gradients
+
 .gradient(@default: #F5F5F5, @start: #EEE, @stop: #FFF) {
     .linear-gradient-top(@default,@start,0%,@stop,100%);
 }
@@ -201,18 +205,21 @@
 }
 
 
-/* Opacity */
+// Opacity
+
 .opacity(@factor){
     opacity: @factor;
 }
 
 
-/* Text Shadow */
+// Text Shadow
+
 .text-shadow(@args){
     text-shadow: @args;
 }
 
-/* Transforms */
+
+// Transforms
 
 .transform(@args) {
     -webkit-transform: @args; 
@@ -236,7 +243,7 @@
 }
 
 
-/* Transitions */
+// Transitions
 
 .transition(@args:200ms) {
     -webkit-transition: @args;
@@ -258,3 +265,4 @@
     -webkit-transition-timing-function: @function;
     transition-timing-function: @function;
 }
+

--- a/prefixer.less
+++ b/prefixer.less
@@ -1,72 +1,73 @@
-/*---------------------------------------------------
-    LESS Prefixer
-  ---------------------------------------------------
-    
-    All of the CSS3 fun, none of the prefixes!
+//---------------------------------------------------
+//  LESS Prefixer
+//---------------------------------------------------
+//
+//  All of the CSS3 fun, none of the prefixes!
+//
+//  As a rule, you can use the CSS properties you
+//  would expect just by adding a '.':
+//
+//  box-shadow => .box-shadow(@args)
+//
+//  Also, when shorthand is available, arguments are
+//  not parameterized. Learn CSS, not LESS Prefixer.
+//
+//  -------------------------------------------------
+//  TABLE OF CONTENTS
+//  (*) denotes a syntax-sugar helper
+//  -------------------------------------------------
+//
+//      .animation(@args)
+//          .animation-delay(@delay)
+//          .animation-direction(@direction)
+//          .animation-duration(@duration)
+//          .animation-iteration-count(@count)
+//          .animation-name(@name)
+//          .animation-play-state(@state)
+//          .animation-timing-function(@function)
+//      .background-size(@args)
+//      .border-radius(@args)
+//      .box-shadow(@args)
+//          .inner-shadow(@args) *
+//      .box-sizing(@args)
+//          .border-box() *
+//          .content-box() *
+//      .columns(@args)
+//          .column-count(@count)
+//          .column-gap(@gap)
+//          .column-rule(@args)
+//          .column-width(@width)
+//      .gradient(@default,@start,@stop) *
+//          .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
+//          .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
+//      .opacity(@factor)
+//      .transform(@args)
+//          .rotate(@deg)
+//          .scale(@factor)
+//          .translate(@x,@y)
+//          .translate3d(@x,@y,@z)
+//          .translateHardware(@x,@y) *
+//      .text-shadow(@args)
+//      .transition(@args)
+//          .transition-delay(@delay)
+//          .transition-duration(@duration)
+//          .transition-property(@property)
+//          .transition-timing-function(@function)
+//
+//
+//
+//  Credit to LESS Elements for the motivation and
+//  to CSS3Please.com for implementation.
+//
+//  Copyright (c) 2012 Joel Sutherland
+//  MIT Licensed:
+//  http://www.opensource.org/licenses/mit-license.php
+//
+//---------------------------------------------------
 
-    As a rule, you can use the CSS properties you
-    would expect just by adding a '.':
 
-    box-shadow => .box-shadow(@args)
+// Animation
 
-    Also, when shorthand is available, arguments are
-    not parameterized. Learn CSS, not LESS Prefixer.
-
-    -------------------------------------------------
-    TABLE OF CONTENTS
-    (*) denotes a syntax-sugar helper
-    -------------------------------------------------
-
-        .animation(@args)
-            .animation-delay(@delay)
-            .animation-direction(@direction)
-            .animation-duration(@duration)
-            .animation-iteration-count(@count)
-            .animation-name(@name)
-            .animation-play-state(@state)
-            .animation-timing-function(@function)
-        .background-size(@args)
-        .border-radius(@args)
-        .box-shadow(@args)
-            .inner-shadow(@args) *
-        .box-sizing(@args)
-            .border-box() *
-            .content-box() *
-        .columns(@args)
-            .column-count(@count)
-            .column-gap(@gap)
-            .column-rule(@args)
-            .column-width(@width)
-        .gradient(@default,@start,@stop) *
-            .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
-            .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
-        .opacity(@factor)
-        .transform(@args)
-            .rotate(@deg)
-            .scale(@factor)
-            .translate(@x,@y)
-            .translate3d(@x,@y,@z)
-            .translateHardware(@x,@y) *
-        .text-shadow(@args)
-        .transition(@args)
-            .transition-delay(@delay)
-            .transition-duration(@duration)
-            .transition-property(@property)
-            .transition-timing-function(@function)
-
-
-
-    Credit to LESS Elements for the motivation and
-    to CSS3Please.com for implementation.
-
-    Copyright (c) 2012 Joel Sutherland
-    MIT Licensed:
-    http://www.opensource.org/licenses/mit-license.php
-
------------------------------------------------------*/
-
-
-/* Animation */
 .animation(@args) {
     -webkit-animation: @args;
     -moz-animation: @args;
@@ -117,7 +118,7 @@
 }
 
 
-/* Background Size */
+// Background Size
 
 .background-size(@args) {
     -webkit-background-size: @args;
@@ -126,7 +127,7 @@
 }
 
 
-/* Border Radius */
+// Border Radius
 
 .border-radius(@args) {
     -webkit-border-radius: @args;
@@ -139,7 +140,8 @@
 }
 
 
-/* Box Shadows */
+// Box Shadows
+
 .box-shadow(@args) {
     -webkit-box-shadow: @args;
     -moz-box-shadow: @args;
@@ -150,7 +152,8 @@
 }
 
 
-/* Box Sizing */
+// Box Sizing
+
 .box-sizing(@args){
     -webkit-box-sizing: @args;
     -moz-box-sizing: @args;
@@ -164,8 +167,8 @@
 }
 
 
+// Columns
 
-/* Columns */
 .columns(@args){
     -webkit-columns: @args;
     -moz-columns: @args;
@@ -193,7 +196,8 @@
 }
 
 
-/* Gradients */
+// Gradients
+
 .gradient(@default: #F5F5F5, @start: #EEE, @stop: #FFF) {
     .linear-gradient-top(@default,@start,0%,@stop,100%);
 }
@@ -253,7 +257,8 @@
 }
 
 
-/* Opacity */
+// Opacity
+
 .opacity(@factor){
     opacity: @factor;
     @iefactor: @factor*100;
@@ -261,12 +266,14 @@
 }
 
 
-/* Text Shadow */
+// Text Shadow
+
 .text-shadow(@args){
     text-shadow: @args;
 }
 
-/* Transforms */
+
+// Transforms
 
 .transform(@args) {
     -webkit-transform: @args; 
@@ -294,7 +301,7 @@
 }
 
 
-/* Transitions */
+// Transitions
 
 .transition(@args:200ms) {
     -webkit-transition: @args;
@@ -326,3 +333,4 @@
     -o-transition-timing-function: @function;
     transition-timing-function: @function;
 }
+


### PR DESCRIPTION
When importing the LESS-Prefixer mixin via

```
@import "mixins/LESS-Prefixer/prefixer.less";
```

all library comments are part of the final CSS output (when not minified).

Since the do not make any sence in the pure CSS world, use the LESS comment style.
See http://lesscss.org/#-comments
