### PR TITLE
Merging declarations and adding user-select mixing

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -68,6 +68,7 @@ Additionally, each mixin uses the correct vendor prefixes as indicated by [CSS3P
 	* .transition-duration(@duration)
 	* .transition-property(@property)
 	* .transition-timing-function(@function)
+* .text-shadow(@select)
 
 ## Credits
 

--- a/prefixer.less
+++ b/prefixer.less
@@ -281,7 +281,7 @@
 // Text Shadow
 
 .text-shadow(@args) {
-    text-shadow: @args;
+    text-shadow+: @args;
 }
 
 

--- a/prefixer.less
+++ b/prefixer.less
@@ -373,14 +373,14 @@
 // Selections
 
 .user-select(@select:none) {
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+    -webkit-user-select: @select;
+    -khtml-user-select: @select;
+    -moz-user-select: @select;
+    -ms-user-select: @select;
+    user-select: @select;
 
     & when (@select = none) {
-        -webkit-touch-callout: none;
+        -webkit-touch-callout: @select;
     }
 }
 

--- a/prefixer.less
+++ b/prefixer.less
@@ -333,11 +333,11 @@
 // Transitions
 
 .transition(@args:200ms) {
-    -webkit-transition: @args;
-    -moz-transition: @args;
-    -o-transition: @args;
-    -ms-transition: @args;
-    transition: @args;
+    -webkit-transition+: @args;
+    -moz-transition+: @args;
+    -o-transition+: @args;
+    -ms-transition+: @args;
+    transition+: @args;
 }
 .transition-delay(@delay:0) {
     -webkit-transition-delay: @delay;

--- a/prefixer.less
+++ b/prefixer.less
@@ -56,6 +56,7 @@
 //          .transition-duration(@duration)
 //          .transition-property(@property)
 //          .transition-timing-function(@function)
+//      .user-select(@select)
 //
 //
 //
@@ -366,5 +367,20 @@
     -o-transition-timing-function: @function;
     -ms-transition-timing-function: @function;
     transition-timing-function: @function;
+}
+
+
+// Selections
+
+.user-select(@select:none) {
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+
+    & when (@select = none) {
+        -webkit-touch-callout: none;
+    }
 }
 


### PR DESCRIPTION
Changes:

* merging `transition` calls
* merging `text-shadow` calls
* adding a `user-select` mixing that can handle `webkit-touch-callout` basics
* updates to docs and toc

If you want a smaller PR with just some of these changes just let's me know. Same goes for any code or style changes you would like to see - I tried to make my code/docs look like what you had in place.