### PR TITLE
Adds @keyframes support.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,6 +40,7 @@ Additionally, each mixin uses the correct vendor prefixes as indicated by [CSS3P
 	* .animation-name(@name)
 	* .animation-play-state(@state)
 	* .animation-timing-function(@function)
+	* .keyframes(@name, @frames)  (@frames should be a block containing keyframes)
 * .background-size(@args)
 * .border-radius(@args)
 * .box-shadow(@args)

--- a/prefixer.less
+++ b/prefixer.less
@@ -26,6 +26,7 @@
 //          .animation-name(@name)
 //          .animation-play-state(@state)
 //          .animation-timing-function(@function)
+//          .keyframes(@name, @frames) [@frames should be a block containing keyframes]
 //      .background-size(@args)
 //      .border-radius(@args)
 //      .box-shadow(@args)
@@ -144,6 +145,12 @@
     -ms-animation-timing-function: @function;
     -o-animation-timing-function: @function;
     animation-timing-function: @function;
+}
+.keyframes(@name, @frames) { 
+    @-webkit-keyframes @name { @frames(); }
+    @-moz-keyframes @name { @frames(); }
+    @-o-keyframes @name { @frames(); }
+    @keyframes @name { @frames(); }
 }
 
 


### PR DESCRIPTION
Adds a mixin for prefixing the keyframes at-rule used in animation. Tested in LESS v1.7.5.
Requires LESS v1.7.0 or above:
http://lesscss.org/features/#variables-feature-properties
http://lesscss.org/features/#detached-rulesets-feature

Example usage would be:

``` less
.keyframes(stretch, {
    from {
        width: 10%;
    }
    to {
        width: 100%;
    }
});
```
