### PR TITLE
Added two new functions

### DIFF
--- a/prefixer.less
+++ b/prefixer.less
@@ -17,6 +17,7 @@
 //  (*) denotes a syntax-sugar helper
 //  -------------------------------------------------
 //
+//      ._prefix(@property, @args)
 //      .animation(@args)
 //          .animation-delay(@delay)
 //          .animation-direction(@direction)
@@ -26,6 +27,7 @@
 //          .animation-name(@name)
 //          .animation-play-state(@state)
 //          .animation-timing-function(@function)
+//      .backface-visibility(@visibility)
 //      .background-size(@args)
 //      .border-radius(@args)
 //      .box-shadow(@args)
@@ -57,7 +59,7 @@
 //          .transition-duration(@duration)
 //          .transition-property(@property)
 //          .transition-timing-function(@function)
-//      Flexbox: 
+//      Flexbox:
 //          .flex-block()
 //          .flex-inline()
 //              .flex-flow(@direction: row, @wrap: nowrap)
@@ -81,6 +83,17 @@
 //  http://www.opensource.org/licenses/mit-license.php
 //
 //---------------------------------------------------
+
+
+// All Purpose
+
+._prefix(@property, @args...) {
+    -webkit-@{property}: @args;
+    -moz-@{property}: @args;
+    -ms-@{property}: @args;
+    -o-@{property}: @args;
+    @{property}: @args;
+}
 
 
 // Animation
@@ -145,6 +158,15 @@
     -ms-animation-timing-function: @function;
     -o-animation-timing-function: @function;
     animation-timing-function: @function;
+}
+
+
+// Backface Visibility
+
+.backface-visibility(@visibility) {
+    -webkit-backface-visibility: @visibility;
+    -moz-backface-visibility: @visibility;
+    backface-visibility: @visibility;
 }
 
 
@@ -291,7 +313,7 @@
     opacity: @factor;
 }
 
-// Key Frames 
+// Key Frames
 .keyframes(@name; @args) {
 	@-moz-keyframes @name { @args(); }
 	@-webkit-keyframes @name { @args(); }


### PR DESCRIPTION
`.backface-visibility` - because it was missing. 
`._prefix` - a generic prefixer that can be used for any property that follows a very basic prefixing pattern. You wouldn't want to use this in most cases but if some property doesn't have a function available yet, it might work. For example:

```less
._prefix(backface-visibility, hidden);
```

Should give you the property from the first argument prefixed in all the typical ways.
