### PR TITLE
Support for calc()

### DIFF
--- a/prefixer.less
+++ b/prefixer.less
@@ -196,6 +196,19 @@
     column-rule: @args;
 }
 
+// Filters
+
+.filter(@args) {
+	-webkit-filter: @args;
+	-moz-filter: @args;
+	-o-filter: @args;
+	-ms-filter: @args;
+	filter: @args;
+}
+
+.blur(@px) {
+	.filter(blur(@px));
+}
 
 // Gradients
 
@@ -399,4 +412,24 @@
     -ms-align-self: @align;
     -webkit-align-self: @align;
     align-self: @align;
+}
+
+// calculations
+
+// please note that to prevent the Less compiler from
+// touching the expression, it needs to be quoted
+// like this: .height-calc(~"100% - 10px");
+
+.height-calc(@s) {
+	height: -moz-calc(@s);
+	height: -webkit-calc(@s);
+	height: -o-calc(@s);
+	height: calc(@s);
+}
+
+.width-calc(@s) {
+	width: -moz-calc(@s);
+	width: -webkit-calc(@s);
+	width: -o-calc(@s);
+	width: calc(@s);
 }


### PR DESCRIPTION
I couldn’t figure out how to write a pure calc function (that would
allow me to do `width: .calc(100% - 10px);` since the mixins want to
output whole lines, so I had to create .width-calc() and .height-calc().

also .width-calc(100% - 10px); will not work because the Less compiler
performs the calculation before passing it to the mixin, so the
expression needs to be stated with literals like this:
`.width-calc(~”100% - 10px”);`