### PR TITLE
support multi-argument animations and shadows

### DIFF
--- a/prefixer.less
+++ b/prefixer.less
@@ -82,9 +82,10 @@
 //  http://www.opensource.org/licenses/mit-license.php
 //
 //---------------------------------------------------
-}
 
-.animation(@args) {
+
+.animation(@arg0, @rest: endOfArgs, ...) {
+	@args: ~`"@{arguments}".replace(/[\[\]]|\,\sendOfArgs/g, '')`;
 	-webkit-animation: @args;
 	animation: @args;
 }
@@ -141,13 +142,15 @@
 }
 
 // Box Shadows
-.box-shadow(@args) {
+.box-shadow(@arg0, @rest: endOfArgs, ...) {
+	@args: ~`"@{arguments}".replace(/[\[\]]|\,\sendOfArgs/g, '')`;
 	-webkit-box-shadow: @args;
 	box-shadow: @args;
 }
 
-.inner-shadow(@args) {
-	.box-shadow(inset @args);
+.inner-shadow(@arg0, @rest: endOfArgs, ...) {
+  @innerArgs: ~`"@{arguments}".replace(/[\[\]]|\,\endOfArgs/g, '').replace(/^/g,'inset ').replace(/,/g,', inset')`;
+  .box-shadow(@innerArgs);
 }
 
 // Box Sizing
@@ -254,7 +257,9 @@
 }
 
 // Text Shadow
-.text-shadow(@args) {
+
+.text-shadow(@arg0, @rest: endOfArgs, ...) {
+	@args: ~`"@{arguments}".replace(/[\[\]]|\,\sendOfArgs/g, '')`;
 	text-shadow: @args;
 }
 

--- a/prefixer.less
+++ b/prefixer.less
@@ -17,6 +17,7 @@
 //  (*) denotes a syntax-sugar helper
 //  -------------------------------------------------
 //
+//      .keyframes(@name; @args)
 //      .animation(@args)
 //          .animation-delay(@delay)
 //          .animation-direction(@direction)
@@ -41,7 +42,6 @@
 //      .gradient(@default,@start,@stop) *
 //          .linear-gradient-top(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
 //          .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
-//      .keyframes(@name; @args)
 //      .opacity(@factor)
 //      .text-shadow(@args)
 //      .transform(@args)
@@ -82,7 +82,16 @@
 //  http://www.opensource.org/licenses/mit-license.php
 //
 //---------------------------------------------------
-
+// Animation
+.keyframes(@name;
+@args) {
+	@-webkit-keyframes @name {
+		@args();
+	}
+	@keyframes @name {
+		@args();
+	}
+}
 
 .animation(@arg0, @rest: endOfArgs, ...) {
 	@args: ~`"@{arguments}".replace(/[\[\]]|\,\sendOfArgs/g, '')`;
@@ -238,17 +247,6 @@
 	background-color: @default;
 	background-image: -webkit-linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
 	background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
-}
-
-// Animation
-.keyframes(@name;
-@args) {
-	@-webkit-keyframes @name {
-		@args();
-	}
-	@keyframes @name {
-		@args();
-	}
 }
 
 // Opacity

--- a/prefixer.less
+++ b/prefixer.less
@@ -17,7 +17,6 @@
 //  (*) denotes a syntax-sugar helper
 //  -------------------------------------------------
 //
-//      .keyframes(@name; @args)
 //      .animation(@args)
 //          .animation-delay(@delay)
 //          .animation-direction(@direction)
@@ -44,6 +43,7 @@
 //          .linear-gradient-left(@default,@color1,@stop1,@color2,@stop2,[@color3,@stop3,@color4,@stop4])*
 //      .keyframes(@name; @args)
 //      .opacity(@factor)
+//      .text-shadow(@args)
 //      .transform(@args)
 //          .transform-origin(@args)
 //          .transform-style(@style)
@@ -52,12 +52,12 @@
 //          .translate(@x,@y)
 //          .translate3d(@x,@y,@z)
 //          .translateHardware(@x,@y) *
-//      .text-shadow(@args)
 //      .transition(@args)
 //          .transition-delay(@delay)
 //          .transition-duration(@duration)
 //          .transition-property(@property)
 //          .transition-timing-function(@function)
+//      .user-select(@select)
 //      Flexbox: 
 //          .flex-block()
 //          .flex-inline()
@@ -82,15 +82,6 @@
 //  http://www.opensource.org/licenses/mit-license.php
 //
 //---------------------------------------------------
-// Animation
-.keyframes(@name;
-@args) {
-	@-webkit-keyframes @name {
-		@args();
-	}
-	@keyframes @name {
-		@args();
-	}
 }
 
 .animation(@args) {
@@ -246,12 +237,15 @@
 	background-image: linear-gradient(left, @color1 @stop1, @color2 @stop2, @color3 @stop3, @color4 @stop4);
 }
 
-// UserSelect
-.user-select(@select: auto) {
-	-webkit-user-select: @select;
-	-moz-user-select: @select;
-	-ms-user-select: @select;
-	user-select: @select;
+// Animation
+.keyframes(@name;
+@args) {
+	@-webkit-keyframes @name {
+		@args();
+	}
+	@keyframes @name {
+		@args();
+	}
 }
 
 // Opacity
@@ -333,6 +327,14 @@
 
 .transition-timing-function(@function: ease) {
 	transition-timing-function: @function;
+}
+
+// UserSelect
+.user-select(@select: auto) {
+	-webkit-user-select: @select;
+	-moz-user-select: @select;
+	-ms-user-select: @select;
+	user-select: @select;
 }
 
 // Flexbox


### PR DESCRIPTION
Adds support for

- `animation: animation1, animation2, ...` via `.animation(animation1, animation2, ...)`
- `box-shadow: shadow1, shadow2, ...` via `.box-shadow(shadow1, shadow2, ...)` (solves #47)
- `text-shadow: shadow1, shadow2, ...` via `.text-shadow(shadow1, shadow2, ...)`

h/t @toekneestuck for the basic idea (in [this post](http://www.toekneestuck.com/blog/2012/05/15/less-css-arguments-variable/))

 (😃👋)